### PR TITLE
Add MVP models

### DIFF
--- a/talent_access/jobs/models.py
+++ b/talent_access/jobs/models.py
@@ -1,3 +1,30 @@
 from django.db import models
+from users.models import Utilisateur
 
-# Create your models here.
+
+class OffreEmploi(models.Model):
+    entreprise = models.ForeignKey(Utilisateur, on_delete=models.CASCADE)
+    titre = models.CharField(max_length=255)
+    description = models.TextField()
+    type_contrat = models.CharField(max_length=100)
+    localisation = models.CharField(max_length=255)
+    date_publication = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.titre
+
+
+class Candidature(models.Model):
+    class Statut(models.TextChoices):
+        EN_ATTENTE = 'EN_ATTENTE', 'en attente'
+        ACCEPTEE = 'ACCEPTEE', 'acceptée'
+        REFUSEE = 'REFUSEE', 'refusée'
+
+    offre = models.ForeignKey(OffreEmploi, on_delete=models.CASCADE)
+    candidat = models.ForeignKey(Utilisateur, on_delete=models.CASCADE)
+    date_candidature = models.DateTimeField(auto_now_add=True)
+    lettre_motivation = models.TextField()
+    statut_candidature = models.CharField(max_length=20, choices=Statut.choices)
+
+    def __str__(self):
+        return f"Candidature de {self.candidat.username}"

--- a/talent_access/profiles/models.py
+++ b/talent_access/profiles/models.py
@@ -1,4 +1,38 @@
 from django.db import models
+from users.models import Utilisateur
 
-# Create your models here.
 
+class ProfilDiplome(models.Model):
+    utilisateur = models.ForeignKey(Utilisateur, on_delete=models.CASCADE)
+    numero_telephone = models.CharField(max_length=20)
+    adresse = models.CharField(max_length=255)
+    date_naissance = models.DateField()
+    niveau_etude = models.CharField(max_length=100)
+    cv = models.FileField(upload_to='cvs/', blank=True, null=True)
+
+    def __str__(self):
+        return f"Profil de {self.utilisateur.username}"
+
+
+class Competence(models.Model):
+    class Niveau(models.TextChoices):
+        DEBUTANT = 'DEBUTANT', 'débutant'
+        INTERMEDIAIRE = 'INTERMEDIAIRE', 'intermédiaire'
+        AVANCE = 'AVANCE', 'avancé'
+
+    profil_diplome = models.ForeignKey(ProfilDiplome, on_delete=models.CASCADE)
+    nom = models.CharField(max_length=100)
+    niveau = models.CharField(max_length=20, choices=Niveau.choices)
+
+    def __str__(self):
+        return self.nom
+
+
+class FormationExperience(models.Model):
+    profil_diplome = models.ForeignKey(ProfilDiplome, on_delete=models.CASCADE)
+    diplome_obtenu = models.CharField(max_length=255)
+    date_obtention = models.DateField()
+    duree_formation = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.diplome_obtenu

--- a/talent_access/talent_access/settings.py
+++ b/talent_access/talent_access/settings.py
@@ -123,3 +123,5 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+AUTH_USER_MODEL = 'users.Utilisateur'

--- a/talent_access/users/models.py
+++ b/talent_access/users/models.py
@@ -1,3 +1,15 @@
+from django.contrib.auth.models import AbstractUser
 from django.db import models
 
-# Create your models here.
+
+class Utilisateur(AbstractUser):
+    class Statut(models.TextChoices):
+        DIPLOME = 'DIPLOME', 'Diplômé'
+        PME = 'PME', 'PME'
+
+    email = models.EmailField(unique=True)
+    date_inscription = models.DateTimeField(auto_now_add=True)
+    statut = models.CharField(max_length=20, choices=Statut.choices)
+
+    def __str__(self):
+        return self.username


### PR DESCRIPTION
## Summary
- implement custom `Utilisateur` model with signup date and status choices
- create diploma profiles, skills, and training/experience models
- define job offer and application models
- set `AUTH_USER_MODEL`

## Testing
- `env/bin/python talent_access/manage.py check`

------
https://chatgpt.com/codex/tasks/task_b_6855bb5549fc832fae6ab6df90e8b6bc