### PR TITLE
Add homepage templates

### DIFF
--- a/talent_access/talent_access/urls.py
+++ b/talent_access/talent_access/urls.py
@@ -16,7 +16,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from users import views as user_views
 
 urlpatterns = [
+    path('', user_views.home, name='home'),
     path('admin/', admin.site.urls),
 ]

--- a/talent_access/users/static/css/style.css
+++ b/talent_access/users/static/css/style.css
@@ -1,0 +1,7 @@
+body {
+    font-family: Arial, sans-serif;
+}
+
+h1 {
+    color: #0d6efd;
+}

--- a/talent_access/users/templates/base.html
+++ b/talent_access/users/templates/base.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    {% load static %}
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Talent Access 237{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'css/style.css' %}" rel="stylesheet">
+</head>
+<body class="bg-light d-flex flex-column min-vh-100">
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container">
+            <a class="navbar-brand" href="{% url 'home' %}">Talent Access 237</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{% url 'home' %}">Accueil</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">Espace Diplômé</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">Espace PME</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main class="flex-fill">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="bg-primary text-white text-center py-3 mt-auto">
+        <div class="container">
+            &copy; Talent Access 237
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/talent_access/users/templates/home.html
+++ b/talent_access/users/templates/home.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block title %}Accueil - Talent Access 237{% endblock %}
+
+{% block content %}
+<section class="py-5 text-center container">
+    <div class="row py-lg-5">
+        <div class="col-lg-8 col-md-10 mx-auto">
+            <h1 class="fw-light mb-4">Bienvenue sur Talent Access 237</h1>
+            <p class="lead text-muted">Connectez diplômés et entreprises rapidement</p>
+            <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mt-4">
+                <a href="#" class="btn btn-primary btn-lg px-4">Je suis Diplômé(e)</a>
+                <a href="#" class="btn btn-outline-primary btn-lg px-4">Je suis une PME</a>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/talent_access/users/views.py
+++ b/talent_access/users/views.py
@@ -1,3 +1,7 @@
 from django.shortcuts import render
 
-# Create your views here.
+
+def home(request):
+    """Render the application home page."""
+    return render(request, "home.html")
+


### PR DESCRIPTION
## Summary
- create base and home templates using Bootstrap
- add minimal CSS
- implement `home` view and route it from root URLs

## Testing
- `python talent_access/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6855be12a7ac832fb78fe7d30fb6e00d