### PR TITLE
Add PME auth templates

### DIFF
--- a/talent_access/users/templates/pme_login.html
+++ b/talent_access/users/templates/pme_login.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+
+{% block title %}Connexion PME - Talent Access 237{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h2 class="card-title text-center mb-4">Connexion PME</h2>
+                    {% if form.errors %}
+                        <div class="alert alert-danger">Mauvais email ou mot de passe.</div>
+                    {% endif %}
+                    <form method="post">
+                        {% csrf_token %}
+                        <div class="mb-3">
+                            {{ form.email.label_tag }}
+                            {{ form.email }}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.password.label_tag }}
+                            {{ form.password }}
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Se connecter à mon compte PME</button>
+                    </form>
+                    <p class="mt-3 text-center">
+                        Pas encore inscrit ? <a href="{% url 'pme_signup' %}">Créez votre compte PME ici</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/talent_access/users/templates/pme_signup.html
+++ b/talent_access/users/templates/pme_signup.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+
+{% block title %}Inscription PME - Talent Access 237{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h2 class="card-title text-center mb-4">Inscription PME</h2>
+                    {% if messages %}
+                        {% for message in messages %}
+                            <div class="alert alert-{{ message.tags }} text-center">{{ message }}</div>
+                        {% endfor %}
+                    {% endif %}
+                    <form method="post">
+                        {% csrf_token %}
+                        {{ form.non_field_errors }}
+                        <div class="mb-3">
+                            {{ form.email.label_tag }}
+                            {{ form.email }}
+                            {% for error in form.email.errors %}
+                                <div class="text-danger small">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.company_name.label_tag }}
+                            {{ form.company_name }}
+                            {% for error in form.company_name.errors %}
+                                <div class="text-danger small">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.sector.label_tag }}
+                            {{ form.sector }}
+                            {% for error in form.sector.errors %}
+                                <div class="text-danger small">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.password1.label_tag }}
+                            {{ form.password1 }}
+                            {% for error in form.password1.errors %}
+                                <div class="text-danger small">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <div class="mb-3">
+                            {{ form.password2.label_tag }}
+                            {{ form.password2 }}
+                            {% for error in form.password2.errors %}
+                                <div class="text-danger small">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Créer mon compte PME</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add PME signup template for SMBs
- add PME login template with link to signup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855c0bca5f8832fa51783079addc91b