### PR TITLE
Improve PME dashboard UI

### DIFF
--- a/talent_access/users/templates/pme_dashboard.html
+++ b/talent_access/users/templates/pme_dashboard.html
@@ -2,7 +2,95 @@
 {% block title %}Tableau de bord PME{% endblock %}
 {% block content %}
 <div class="container py-5">
-    <h2 class="text-center">Bienvenue, {{ request.user.first_name }} !</h2>
-    <p class="text-center">Vous êtes connecté en tant que PME.</p>
+    <h2 class="text-center mb-4">Bienvenue, {{ request.user.first_name }} !</h2>
+
+    <div class="mb-5">
+        <h4>Profil de l'entreprise</h4>
+        <ul class="list-group">
+            <li class="list-group-item"><strong>Nom :</strong> {{ request.user.first_name }}</li>
+            <li class="list-group-item"><strong>Secteur :</strong> {{ request.user.last_name }}</li>
+            <li class="list-group-item"><strong>Email :</strong> {{ request.user.email }}</li>
+        </ul>
+        <a href="#" class="btn btn-link mt-2">Modifier mon profil</a>
+    </div>
+
+    <div class="mb-5">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h4 class="mb-0">Mes offres d'emploi</h4>
+            <a href="#" class="btn btn-primary">Nouvelle offre</a>
+        </div>
+        {% if offres %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Titre</th>
+                        <th>Date</th>
+                        <th>Type de contrat</th>
+                        <th>Candidatures</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for offre in offres %}
+                    <tr>
+                        <td>{{ offre.titre }}</td>
+                        <td>{{ offre.date_publication|date:"d/m/Y" }}</td>
+                        <td>{{ offre.type_contrat }}</td>
+                        <td>{{ offre.candidature_set.count }}</td>
+                        <td>
+                            <a href="#" class="btn btn-sm btn-outline-primary">Voir</a>
+                            <a href="#" class="btn btn-sm btn-outline-secondary">Modifier</a>
+                            <a href="#" class="btn btn-sm btn-outline-danger">Supprimer</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-muted">Aucune offre n'a encore été créée.</p>
+        {% endif %}
+    </div>
+
+    <div class="mb-5">
+        <h4 class="mb-3">Candidatures reçues</h4>
+        {% if candidatures %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Candidat</th>
+                        <th>CV</th>
+                        <th>Statut</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for c in candidatures %}
+                    <tr>
+                        <td>{{ c.candidat.first_name }} {{ c.candidat.last_name }}</td>
+                        <td>
+                            {% with profil=c.candidat.profildiplome_set.first %}
+                                {% if profil and profil.cv %}
+                                    <a href="{{ profil.cv.url }}" class="btn btn-sm btn-outline-primary">Télécharger</a>
+                                {% else %}
+                                    <span class="text-muted">Aucun CV</span>
+                                {% endif %}
+                            {% endwith %}
+                        </td>
+                        <td>{{ c.get_statut_candidature_display }}</td>
+                        <td><a href="#" class="btn btn-sm btn-outline-primary">Répondre</a></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-muted">Aucune candidature pour le moment.</p>
+        {% endif %}
+    </div>
+
+    <a href="#" class="btn btn-outline-secondary">Accéder à la messagerie</a>
 </div>
 {% endblock %}

--- a/talent_access/users/views.py
+++ b/talent_access/users/views.py
@@ -4,6 +4,8 @@ from .forms import DiplomeSignupForm, PMESignupForm, EmailAuthenticationForm
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from .models import Utilisateur
+from jobs.models import OffreEmploi, Candidature
+from profiles.models import ProfilDiplome
 
 
 def home(request):
@@ -74,4 +76,20 @@ def diplome_dashboard(request):
 def pme_dashboard(request):
     if request.user.statut != Utilisateur.Statut.PME:
         return redirect("diplome_dashboard")
-    return render(request, "pme_dashboard.html")
+    offres = (
+        OffreEmploi.objects.filter(entreprise=request.user)
+        .order_by("-date_publication")
+    )
+    candidatures = (
+        Candidature.objects.filter(offre__entreprise=request.user)
+        .select_related("candidat", "offre")
+        .order_by("-date_candidature")
+    )
+    return render(
+        request,
+        "pme_dashboard.html",
+        {
+            "offres": offres,
+            "candidatures": candidatures,
+        },
+    )


### PR DESCRIPTION
## Summary
- show PME profile on dashboard
- list company offers and received applications

## Testing
- `python talent_access/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6855ca6d0570832fa1b2e3a945e16063