### PR TITLE
Adjust dashboard templates

### DIFF
--- a/talent_access/users/templates/dashboard_base.html
+++ b/talent_access/users/templates/dashboard_base.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    {% load static %}
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Talent Access 237{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'css/style.css' %}" rel="stylesheet">
+</head>
+<body class="bg-light d-flex flex-column min-vh-100">
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container">
+            <a class="navbar-brand" href="{% url 'home' %}">Talent Access 237</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav"></div>
+        </div>
+    </nav>
+
+    <main class="flex-fill">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="bg-primary text-white text-center py-3 mt-auto">
+        <div class="container">
+            &copy; Talent Access 237
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/talent_access/users/templates/diplome_dashboard.html
+++ b/talent_access/users/templates/diplome_dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'dashboard_base.html' %}
 {% block title %}Tableau de bord Diplômé{% endblock %}
 {% block content %}
 <div class="container py-5">

--- a/talent_access/users/templates/pme_dashboard.html
+++ b/talent_access/users/templates/pme_dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'dashboard_base.html' %}
 {% block title %}Tableau de bord PME{% endblock %}
 {% block content %}
 <div class="container py-5">


### PR DESCRIPTION
## Summary
- create a stripped-down `dashboard_base.html`
- extend `dashboard_base.html` in the two dashboard pages

## Testing
- `pytest -q`
- `python talent_access/manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_b_6855cc04d838832fb7cd3437f47b8ed8