### PR TITLE
Add PME profile management

### DIFF
--- a/talent_access/profiles/forms.py
+++ b/talent_access/profiles/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import ProfilPME
+
+
+class ProfilPMEForm(forms.ModelForm):
+    class Meta:
+        model = ProfilPME
+        exclude = ('utilisateur',)

--- a/talent_access/profiles/migrations/0003_profilpme.py
+++ b/talent_access/profiles/migrations/0003_profilpme.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0002_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProfilPME',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('nom_entreprise', models.CharField(max_length=255)),
+                ('secteur_activite', models.CharField(max_length=255)),
+                ('adresse', models.CharField(max_length=255)),
+                ('site_web', models.URLField(blank=True, null=True)),
+                ('logo', models.ImageField(blank=True, null=True, upload_to='logos/')),
+                ('utilisateur', models.OneToOneField(on_delete=models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/talent_access/profiles/models.py
+++ b/talent_access/profiles/models.py
@@ -36,3 +36,15 @@ class FormationExperience(models.Model):
 
     def __str__(self):
         return self.diplome_obtenu
+
+
+class ProfilPME(models.Model):
+    utilisateur = models.OneToOneField(Utilisateur, on_delete=models.CASCADE)
+    nom_entreprise = models.CharField(max_length=255)
+    secteur_activite = models.CharField(max_length=255)
+    adresse = models.CharField(max_length=255)
+    site_web = models.URLField(blank=True, null=True)
+    logo = models.ImageField(upload_to='logos/', blank=True, null=True)
+
+    def __str__(self):
+        return self.nom_entreprise

--- a/talent_access/profiles/templates/modifier_profil_pme.html
+++ b/talent_access/profiles/templates/modifier_profil_pme.html
@@ -1,0 +1,21 @@
+{% extends 'dashboard_base.html' %}
+{% block title %}Modifier Profil PME{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h2 class="text-center mb-4">Modifier mon profil</h2>
+    <form method="post" enctype="multipart/form-data" class="mx-auto" style="max-width:600px;">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {% for field in form %}
+            <div class="mb-3">
+                {{ field.label_tag }}
+                {{ field }}
+                {% for error in field.errors %}
+                    <div class="text-danger small">{{ error }}</div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+        <button type="submit" class="btn btn-primary">Enregistrer</button>
+    </form>
+</div>
+{% endblock %}

--- a/talent_access/profiles/templates/profil_pme.html
+++ b/talent_access/profiles/templates/profil_pme.html
@@ -1,0 +1,21 @@
+{% extends 'dashboard_base.html' %}
+{% block title %}Mon Profil PME{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h2 class="text-center mb-4">Profil de l'entreprise</h2>
+    {% if profil %}
+    <ul class="list-group mb-3">
+        <li class="list-group-item"><strong>Nom :</strong> {{ profil.nom_entreprise }}</li>
+        <li class="list-group-item"><strong>Secteur :</strong> {{ profil.secteur_activite }}</li>
+        <li class="list-group-item"><strong>Adresse :</strong> {{ profil.adresse }}</li>
+        <li class="list-group-item"><strong>Site web :</strong> {{ profil.site_web|default:'-' }}</li>
+        {% if profil.logo %}
+            <li class="list-group-item"><img src="{{ profil.logo.url }}" alt="Logo" class="img-fluid"/></li>
+        {% endif %}
+    </ul>
+    {% else %}
+        <p class="text-muted">Aucun profil renseigné.</p>
+    {% endif %}
+    <a href="{% url 'modifier_profil_pme' %}" class="btn btn-primary">Modifier</a>
+</div>
+{% endblock %}

--- a/talent_access/profiles/views.py
+++ b/talent_access/profiles/views.py
@@ -1,4 +1,34 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect, get_object_or_404
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 
-# Create your views here.
+from users.models import Utilisateur
+from .models import ProfilPME
+from .forms import ProfilPMEForm
+
+
+@login_required
+def voir_profil_pme(request):
+    if request.user.statut != Utilisateur.Statut.PME:
+        return redirect("diplome_dashboard")
+    profil = ProfilPME.objects.filter(utilisateur=request.user).first()
+    return render(request, "profil_pme.html", {"profil": profil})
+
+
+@login_required
+def modifier_profil_pme(request):
+    if request.user.statut != Utilisateur.Statut.PME:
+        return redirect("diplome_dashboard")
+    profil, _ = ProfilPME.objects.get_or_create(utilisateur=request.user)
+    if request.method == "POST":
+        form = ProfilPMEForm(request.POST, request.FILES, instance=profil)
+        if form.is_valid():
+            form.instance.utilisateur = request.user
+            form.save()
+            messages.success(request, "Profil mis à jour.")
+            return redirect("voir_profil_pme")
+    else:
+        form = ProfilPMEForm(instance=profil)
+    return render(request, "modifier_profil_pme.html", {"form": form})
+
 

--- a/talent_access/talent_access/urls.py
+++ b/talent_access/talent_access/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import path
 from users import views as user_views
+from profiles import views as profile_views
 
 urlpatterns = [
     path('', user_views.home, name='home'),
@@ -11,4 +12,6 @@ urlpatterns = [
     path('pme/login/', user_views.pme_login, name='pme_login'),
     path('diplome/dashboard/', user_views.diplome_dashboard, name='diplome_dashboard'),
     path('pme/dashboard/', user_views.pme_dashboard, name='pme_dashboard'),
+    path('pme/profil/', profile_views.voir_profil_pme, name='voir_profil_pme'),
+    path('pme/profil/modifier/', profile_views.modifier_profil_pme, name='modifier_profil_pme'),
 ]

--- a/talent_access/users/templates/pme_dashboard.html
+++ b/talent_access/users/templates/pme_dashboard.html
@@ -11,7 +11,7 @@
             <li class="list-group-item"><strong>Secteur :</strong> {{ request.user.last_name }}</li>
             <li class="list-group-item"><strong>Email :</strong> {{ request.user.email }}</li>
         </ul>
-        <a href="#" class="btn btn-link mt-2">Modifier mon profil</a>
+        <a href="{% url 'voir_profil_pme' %}" class="btn btn-link mt-2">Modifier mon profil</a>
     </div>
 
     <div class="mb-5">


### PR DESCRIPTION
## Summary
- add `ProfilPME` model for company profiles
- create form to edit PME profile
- implement PME profile views with access control
- wire profile URLs and links
- provide profile templates
- include migration for new model

## Testing
- `python manage.py test` *(fails: ImageField requires Pillow)*

------
https://chatgpt.com/codex/tasks/task_b_6855cddfda9c832f97f83de2d1da133c