### PR TITLE
Fix email field on PME login page

### DIFF
--- a/talent_access/users/templates/pme_login.html
+++ b/talent_access/users/templates/pme_login.html
@@ -34,13 +34,13 @@
                     {% csrf_token %}
 
                     <div class="form-group mb-4">
-                        <label for="{{ form.email.id_for_label }}" class="form-label">
+                        <label for="id_username" class="form-label">
                             <i class="fas fa-envelope me-2"></i>Adresse email
                         </label>
                         <div class="input-group">
-                            {{ form.email }}
+                            {{ form.username }}
                         </div>
-                        {% for error in form.email.errors %}
+                        {% for error in form.username.errors %}
                             <div class="form-error">
                                 <i class="fas fa-exclamation-circle me-1"></i>{{ error }}
                             </div>


### PR DESCRIPTION
## Summary
- correct the PME login template to render the email field

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6856e95d2188832f946b5bf5dad0ed51