### PR TITLE
Add job offer detail view and links

### DIFF
--- a/talent_access/jobs/templates/offre_detail.html
+++ b/talent_access/jobs/templates/offre_detail.html
@@ -1,0 +1,19 @@
+{% extends 'dashboard_base.html' %}
+{% block title %}Détail de l'offre{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h2 class="mb-4">{{ offre.titre }}</h2>
+    <p><strong>Entreprise :</strong> {{ offre.entreprise.first_name }}</p>
+    <p><strong>Lieu :</strong> {{ offre.localisation }}</p>
+    <p><strong>Type de contrat :</strong> {{ offre.type_contrat }}</p>
+    <p class="mt-4">{{ offre.description }}</p>
+    <div class="mt-4">
+        {% if deja_postule %}
+            <span class="badge bg-secondary">Vous avez déjà postulé à cette offre.</span>
+        {% else %}
+            <a href="{% url 'postuler_offre' offre.id %}" class="btn btn-primary">Postuler</a>
+        {% endif %}
+        <a href="{% url 'diplome_dashboard' %}" class="btn btn-outline-secondary">Retour</a>
+    </div>
+</div>
+{% endblock %}

--- a/talent_access/jobs/urls.py
+++ b/talent_access/jobs/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('offres/<int:offre_id>/', views.offre_detail, name='offre_detail'),
     path('offres/<int:offre_id>/postuler/', views.postuler_offre, name='postuler_offre'),
     path('offres/nouvelle/', views.creer_offre, name='creer_offre'),
     path('mes-candidatures/', views.mes_candidatures, name='mes_candidatures'),

--- a/talent_access/jobs/views.py
+++ b/talent_access/jobs/views.py
@@ -96,3 +96,18 @@ def creer_offre(request):
         form = OffreForm()
 
     return render(request, "creer_offre.html", {"form": form})
+
+
+@login_required
+def offre_detail(request, offre_id):
+    """Display the detail of a job offer for graduates."""
+    if request.user.statut != Utilisateur.Statut.DIPLOME:
+        return redirect("pme_dashboard")
+
+    offre = get_object_or_404(OffreEmploi, id=offre_id)
+    deja_postule = Candidature.objects.filter(offre=offre, candidat=request.user).exists()
+    return render(
+        request,
+        "offre_detail.html",
+        {"offre": offre, "deja_postule": deja_postule},
+    )

--- a/talent_access/users/templates/diplome_dashboard.html
+++ b/talent_access/users/templates/diplome_dashboard.html
@@ -148,10 +148,10 @@
                                         </div>
                                     </div>
                                     <div class="offer-actions">
-                                        <a href="#" class="btn btn-outline-primary btn-sm">
+                                        <a href="{% url 'offre_detail' offre.id %}" class="btn btn-outline-primary btn-sm">
                                             <i class="fas fa-eye me-1"></i>Voir
                                         </a>
-                                        <a href="#" class="btn btn-primary btn-sm">
+                                        <a href="{% url 'postuler_offre' offre.id %}" class="btn btn-primary btn-sm">
                                             <i class="fas fa-paper-plane me-1"></i>Postuler
                                         </a>
                                     </div>


### PR DESCRIPTION
## Summary
- allow grads to view an offer's details
- show a Postuler button in the detail page
- link Voir/Postuler buttons from dashboard to new views

## Testing
- `./env/bin/python talent_access/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685754f72718832f95fd5cb10de4f144