### PR TITLE
Add dashboard return buttons

### DIFF
--- a/talent_access/jobs/templates/offre_detail.html
+++ b/talent_access/jobs/templates/offre_detail.html
@@ -13,7 +13,7 @@
         {% else %}
             <a href="{% url 'postuler_offre' offre.id %}" class="btn btn-primary">Postuler</a>
         {% endif %}
-        <a href="{% url 'diplome_dashboard' %}" class="btn btn-outline-secondary">Retour</a>
+        <a href="{% url 'diplome_dashboard' %}" class="btn btn-outline-secondary">Retour au tableau de bord</a>
     </div>
 </div>
 {% endblock %}

--- a/talent_access/jobs/templates/postuler_offre.html
+++ b/talent_access/jobs/templates/postuler_offre.html
@@ -13,6 +13,7 @@
             {% endfor %}
         </div>
         <button type="submit" class="btn btn-primary">Envoyer ma candidature</button>
+        <a href="{% url 'diplome_dashboard' %}" class="btn btn-outline-secondary ms-2">Retour au tableau de bord</a>
     </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow users to easily navigate back to the dashboard when viewing or applying to an offer

## Testing
- `env/bin/python talent_access/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6857651a77bc832f8ff8c334ca6d7eb8