### PR TITLE
Add PME offer detail and edit features

### DIFF
--- a/talent_access/jobs/templates/modifier_offre.html
+++ b/talent_access/jobs/templates/modifier_offre.html
@@ -1,0 +1,41 @@
+{% extends 'dashboard_base.html' %}
+{% block title %}Modifier l'offre{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h2 class="mb-4">Modifier l'offre</h2>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <div class="mb-3">
+            {{ form.titre.label_tag }}
+            {{ form.titre }}
+            {% for error in form.titre.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <div class="mb-3">
+            {{ form.description.label_tag }}
+            {{ form.description }}
+            {% for error in form.description.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <div class="mb-3">
+            {{ form.type_contrat.label_tag }}
+            {{ form.type_contrat }}
+            {% for error in form.type_contrat.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <div class="mb-3">
+            {{ form.localisation.label_tag }}
+            {{ form.localisation }}
+            {% for error in form.localisation.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <button type="submit" class="btn btn-primary">Enregistrer</button>
+        <a href="{% url 'voir_offre_pme' offre.id %}" class="btn btn-secondary">Annuler</a>
+    </form>
+</div>
+{% endblock %}

--- a/talent_access/jobs/templates/offre_pme_detail.html
+++ b/talent_access/jobs/templates/offre_pme_detail.html
@@ -1,0 +1,14 @@
+{% extends 'dashboard_base.html' %}
+{% block title %}Détail de mon offre{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h2 class="mb-4">{{ offre.titre }}</h2>
+    <p><strong>Lieu :</strong> {{ offre.localisation }}</p>
+    <p><strong>Type de contrat :</strong> {{ offre.type_contrat }}</p>
+    <p class="mt-4">{{ offre.description }}</p>
+    <div class="mt-4">
+        <a href="{% url 'modifier_offre' offre.id %}" class="btn btn-primary">Modifier</a>
+        <a href="{% url 'pme_dashboard' %}" class="btn btn-outline-secondary">Retour</a>
+    </div>
+</div>
+{% endblock %}

--- a/talent_access/jobs/urls.py
+++ b/talent_access/jobs/urls.py
@@ -5,6 +5,8 @@ urlpatterns = [
     path('offres/<int:offre_id>/', views.offre_detail, name='offre_detail'),
     path('offres/<int:offre_id>/postuler/', views.postuler_offre, name='postuler_offre'),
     path('offres/nouvelle/', views.creer_offre, name='creer_offre'),
+    path('mes-offres/<int:offre_id>/', views.offre_pme_detail, name='voir_offre_pme'),
+    path('mes-offres/<int:offre_id>/modifier/', views.modifier_offre, name='modifier_offre'),
     path('mes-candidatures/', views.mes_candidatures, name='mes_candidatures'),
     path('candidatures-recues/', views.candidatures_recues, name='candidatures_recues'),
 ]

--- a/talent_access/jobs/views.py
+++ b/talent_access/jobs/views.py
@@ -111,3 +111,37 @@ def offre_detail(request, offre_id):
         "offre_detail.html",
         {"offre": offre, "deja_postule": deja_postule},
     )
+
+
+@login_required
+def offre_pme_detail(request, offre_id):
+    """Display details of an offer for its PME owner."""
+    if request.user.statut != Utilisateur.Statut.PME:
+        return redirect("diplome_dashboard")
+
+    offre = get_object_or_404(OffreEmploi, id=offre_id, entreprise=request.user)
+    return render(request, "offre_pme_detail.html", {"offre": offre})
+
+
+@login_required
+def modifier_offre(request, offre_id):
+    """Allow a PME to edit one of its job offers."""
+    if request.user.statut != Utilisateur.Statut.PME:
+        return redirect("diplome_dashboard")
+
+    offre = get_object_or_404(OffreEmploi, id=offre_id, entreprise=request.user)
+
+    if request.method == "POST":
+        form = OffreForm(request.POST, instance=offre)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Offre mise \u00e0 jour.")
+            return redirect("pme_dashboard")
+    else:
+        form = OffreForm(instance=offre)
+
+    return render(
+        request,
+        "modifier_offre.html",
+        {"form": form, "offre": offre},
+    )

--- a/talent_access/users/templates/pme_dashboard.html
+++ b/talent_access/users/templates/pme_dashboard.html
@@ -41,8 +41,8 @@
                                 <td>{{ offre.type_contrat }}</td>
                                 <td>{{ offre.candidature_set.count }}</td>
                                 <td>
-                                    <a href="#" class="btn btn-sm btn-outline-primary">Voir</a>
-                                    <a href="#" class="btn btn-sm btn-outline-secondary">Modifier</a>
+                                    <a href="{% url 'voir_offre_pme' offre.id %}" class="btn btn-sm btn-outline-primary">Voir</a>
+                                    <a href="{% url 'modifier_offre' offre.id %}" class="btn btn-sm btn-outline-secondary">Modifier</a>
                                     <a href="#" class="btn btn-sm btn-outline-danger">Supprimer</a>
                                 </td>
                             </tr>


### PR DESCRIPTION
## Summary
- let SME users view offer details
- allow SME users to edit their offers
- expose new endpoints for these pages
- wire up dashboard links to new pages

## Testing
- `python talent_access/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_68576540df84832f8bff525f2de49f8a