### PR TITLE
Add return button on candidatures page

### DIFF
--- a/talent_access/jobs/templates/mes_candidatures.html
+++ b/talent_access/jobs/templates/mes_candidatures.html
@@ -13,5 +13,10 @@
         <li class="list-group-item">Aucune candidature pour le moment.</li>
         {% endfor %}
     </ul>
+    <div class="mt-4">
+        <a href="{% url 'diplome_dashboard' %}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-2"></i>Retour au tableau de bord
+        </a>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a "Retour au tableau de bord" button to the candidatures list

## Testing
- `python talent_access/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685768660010832f9818a5c8f56541a6