### PR TITLE
Implement quick action links for graduates

### DIFF
--- a/talent_access/jobs/templates/liste_offres.html
+++ b/talent_access/jobs/templates/liste_offres.html
@@ -1,0 +1,22 @@
+{% extends 'dashboard_base.html' %}
+{% block title %}Offres d'emploi{% endblock %}
+{% block content %}
+<div class="container py-5">
+    <h2 class="mb-4">Offres d'emploi disponibles</h2>
+    {% if offres %}
+    <div class="list-group">
+        {% for offre in offres %}
+        <a href="{% url 'offre_detail' offre.id %}" class="list-group-item list-group-item-action">
+            <div class="d-flex w-100 justify-content-between">
+                <h5 class="mb-1">{{ offre.titre }}</h5>
+                <small>{{ offre.date_publication|date:"d/m/Y" }}</small>
+            </div>
+            <p class="mb-1 text-muted">{{ offre.entreprise.first_name }} - {{ offre.localisation }}</p>
+        </a>
+        {% endfor %}
+    </div>
+    {% else %}
+    <p class="text-muted">Aucune offre disponible pour le moment.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/talent_access/jobs/urls.py
+++ b/talent_access/jobs/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('offres/', views.liste_offres, name='liste_offres'),
     path('offres/<int:offre_id>/', views.offre_detail, name='offre_detail'),
     path('offres/<int:offre_id>/postuler/', views.postuler_offre, name='postuler_offre'),
     path('offres/nouvelle/', views.creer_offre, name='creer_offre'),

--- a/talent_access/jobs/views.py
+++ b/talent_access/jobs/views.py
@@ -145,3 +145,13 @@ def modifier_offre(request, offre_id):
         "modifier_offre.html",
         {"form": form, "offre": offre},
     )
+
+
+@login_required
+def liste_offres(request):
+    """List all available job offers for graduates."""
+    if request.user.statut != Utilisateur.Statut.DIPLOME:
+        return redirect("pme_dashboard")
+
+    offres = OffreEmploi.objects.all().order_by("-date_publication")
+    return render(request, "liste_offres.html", {"offres": offres})

--- a/talent_access/users/templates/diplome_dashboard.html
+++ b/talent_access/users/templates/diplome_dashboard.html
@@ -203,7 +203,7 @@
                             <i class="fas fa-paper-plane fa-3x text-muted mb-3"></i>
                             <h4>Aucune candidature</h4>
                             <p class="text-muted">Vous n'avez envoyé aucune candidature pour le moment.</p>
-                            <a href="#" class="btn btn-primary">
+                            <a href="{% url 'liste_offres' %}" class="btn btn-primary">
                                 <i class="fas fa-search me-2"></i>Parcourir les offres
                             </a>
                         </div>
@@ -228,11 +228,11 @@
                             <i class="fas fa-user-edit"></i>
                             <span>Modifier profil</span>
                         </a>
-                        <a href="#" class="quick-action-btn">
+                        <a href="{% url 'liste_offres' %}" class="quick-action-btn">
                             <i class="fas fa-search"></i>
                             <span>Rechercher offres</span>
                         </a>
-                        <a href="#" class="quick-action-btn">
+                        <a href="{% url 'modifier_profil_diplome' %}" class="quick-action-btn">
                             <i class="fas fa-file-upload"></i>
                             <span>Mettre à jour CV</span>
                         </a>


### PR DESCRIPTION
## Summary
- create `liste_offres` view and template to show all job offers
- expose new route and update dashboard quick actions
- link the "Parcourir les offres" button to the job list

## Testing
- `python talent_access/manage.py check`
- `python talent_access/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685768fcd3a8832f9ec636d564190270