### PR TITLE
Fix conversation list template

### DIFF
--- a/talent_access/messagerie/templates/messagerie/conversation_list.html
+++ b/talent_access/messagerie/templates/messagerie/conversation_list.html
@@ -6,13 +6,11 @@
     {% if conversations %}
         <ul class="list-group">
         {% for conv in conversations %}
-            {% with other=conv.other_participant(request.user) %}
             <li class="list-group-item d-flex justify-content-between align-items-center">
-                <a href="{% url 'conversation_detail' other.id %}">
-                    {{ other.get_full_name|default:other.email }}
+                <a href="{% url 'conversation_detail' conv.other.id %}">
+                    {{ conv.other.get_full_name|default:conv.other.email }}
                 </a>
             </li>
-            {% endwith %}
         {% endfor %}
         </ul>
     {% else %}

--- a/talent_access/messagerie/views.py
+++ b/talent_access/messagerie/views.py
@@ -9,9 +9,14 @@ from .models import Conversation, Message
 
 @login_required
 def conversation_list(request):
-    conversations = Conversation.objects.filter(
+    conversations_qs = Conversation.objects.filter(
         Q(participant1=request.user) | Q(participant2=request.user)
     )
+    conversations = []
+    for conv in conversations_qs:
+        conv.other = conv.other_participant(request.user)
+        conversations.append(conv)
+
     return render(
         request,
         "messagerie/conversation_list.html",


### PR DESCRIPTION
## Summary
- compute the other participant in each conversation before rendering
- update conversation list template accordingly

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6857d6678408832fa4cf8f0401334b9e