### PR TITLE
Add back button to job offers list

### DIFF
--- a/talent_access/jobs/templates/liste_offres.html
+++ b/talent_access/jobs/templates/liste_offres.html
@@ -18,5 +18,10 @@
     {% else %}
     <p class="text-muted">Aucune offre disponible pour le moment.</p>
     {% endif %}
+    <div class="mt-4">
+        <a href="{% url 'diplome_dashboard' %}" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-left me-2"></i>Retour au tableau de bord
+        </a>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a "Retour au tableau de bord" button on the available job offers page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68582ad3aa9c832f83c7d6c917573d4a